### PR TITLE
issue and PR templates: h2 instead of h1 headers

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,10 +1,8 @@
 ---
-name: Enhancement Template
-about: An enhancement for the project
-labels: enhancement
+name: Misc issue
+about: An issue not fitting the other categories
+labels: default-issue-template
 title: ""
 ---
 
-Description
-===========
 A clear and concise description of what the issue is about.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -5,25 +5,20 @@ labels: bug
 title: "bug: "
 ---
 
-Describe the bug
-================
+## Describe the bug
 A clear and concise description of what the bug is.
 
-To Reproduce
-============
+## To Reproduce
 Steps to reproduce the behavior:
 1. Do X
 2. Type Y
 3. ...
 
-Expected behavior
-=================
+## Expected behavior
 A clear and concise description of what you expected to happen.
 
-Screenshots
-===========
+## Screenshots
 If applicable, add screenshots to help explain your problem.
 
-Additional context
-==================
+## Additional context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -5,18 +5,14 @@ labels: enhancement
 title: "enhancement: "
 ---
 
-Current Situation
-=================
+## Current Situation
 A clear and concise description of what the current functionality is.
 
-Enhancement
-===========
+## Enhancement
 A quick description of the proposed enhancement
 
-Reasoning
-=========
+## Reasoning
 Why should this enhancement be added to the repository?
 
-Implementation
-==============
+## Implementation
 Overview of possible implementations

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,10 @@
-What does this PR do?
-=====================
+## What does this PR do?
 
-Why are we doing this?
-======================
 
-Testing performed
-=================
+## Why are we doing this?
 
-Known bugs/limitations
-======================
+
+## Testing performed
+
+
+## Known bugs/limitations


### PR DESCRIPTION
This makes the titles a bit less shouty / take less screen space
(but there's still the thin separator lines).

## Testing performed
rendered the md files.
haven't actually tested creating a new issue/PR with these templates though.

## Known bugs/limitations
none known